### PR TITLE
Temporary remove of pkg-config's atleast_version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,6 @@ use std::path::PathBuf;
 
 fn main() {
     let lib = pkg_config::Config::new()
-        .atleast_version("4.0.0")
         .probe("smbclient")
         .expect("libsmbclient v4.0.0+ not found");
 


### PR DESCRIPTION
At least in Debian 8 (Jessie), Ubuntu 14.04 (Trusty) and ArchLinux
`pkg-config` reports very low version for `smbclient` (around 0.2.x).